### PR TITLE
bumped supported bower version ranges

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "bower_components"
   ],
   "dependencies": {
-    "knockout": "~3.1.0",
+    "knockout": "3.1.x - 3.2.x",
     "jquery": "~1.10"
   }
 }


### PR DESCRIPTION
I have been using this package in knockout 3.2.0 for a while know and it works. Would like to be able to install it via bower.
